### PR TITLE
Check user & permissions

### DIFF
--- a/continuous_integration/gpuci/build.sh
+++ b/continuous_integration/gpuci/build.sh
@@ -34,6 +34,12 @@ rapids-logger "Check GPU usage"
 nvidia-smi
 
 rapids-logger "Activate conda env"
+# Permission testing
+set -x
+id
+ls -ln /opt/conda/etc/profile.d/conda.sh
+#
+. /opt/conda/etc/profile.d/conda.sh
 conda activate dask
 
 rapids-logger "Install distributed"


### PR DESCRIPTION
This PR re-adds the `. /opt/conda/etc/profile.d/conda.sh` line and also adds some debugging commands to help us figure out why Jenkins is throwing a `permission denied` error.